### PR TITLE
Add API route for DataJud queries

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { numeroProcesso } = req.body
+  if (!numeroProcesso) {
+    return res.status(400).json({ error: 'Missing numeroProcesso' })
+  }
+
+  const payload = {
+    query: {
+      match: {
+        numeroProcesso,
+      },
+    },
+  }
+
+  try {
+    const dataRes = await fetch(
+      'https://api-publica.datajud.cnj.jus.br/api_publica_trf1/_search',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `ApiKey ${process.env.DATAJUD_API_KEY ?? '<API Key>'}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      }
+    )
+
+    if (!dataRes.ok) {
+      const text = await dataRes.text()
+      return res.status(dataRes.status).send(text)
+    }
+
+    const data = await dataRes.json()
+    return res.status(200).json(data)
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({ error: 'Failed to fetch' })
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -121,17 +121,13 @@ export default function App() {
     setIsLoading(true);
 
     try {
-      const res = await fetch(
-        `https://datajud-wiki.cnj.jus.br/api-publica/exemplos/exemplo1?processo=${encodeURIComponent(
-          trimmedInput
-        )}`,
-        {
-          headers: {
-            Authorization:
-              'APIKey cDZHYzlZa0JadVREZDJCendQbXY6SkJlTzNjLV9TRENyQk1RdnFKZGRQdw==',
-          },
-        }
-      );
+      const res = await fetch('/api/search', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ numeroProcesso: trimmedInput }),
+      });
 
       if (!res.ok) {
         throw new Error('Erro ao consultar a API');


### PR DESCRIPTION
## Summary
- create `pages/api/search.ts` to query DataJud
- update chat page to call the new API route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc63b7dc48333ac9b12a0eb37b446