### PR TITLE
Use ChatGPT for summary after DataJud fetch

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -134,7 +134,8 @@ export default function App() {
       }
 
       const data = await res.json();
-      typeBotMessage(JSON.stringify(data, null, 2));
+      const message = data.summary ?? JSON.stringify(data, null, 2);
+      typeBotMessage(message);
     } catch (error) {
       typeBotMessage(`Erro: ${(error as Error).message}`);
     }


### PR DESCRIPTION
## Summary
- summarize process movements using ChatGPT API after DataJud request
- display ChatGPT response instead of raw DataJud JSON

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddc4cdcb48333b47f47108770f33d