### PR TITLE
Add PWA support

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,17 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { useEffect } from "react";
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("/sw.js").catch(() => {
+          // registration failed
+        });
+      });
+    }
+  }, []);
+
   return <Component {...pageProps} />;
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,10 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#000000" />
+      </Head>
       <body className="antialiased">
         <Main />
         <NextScript />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Consulta Processual App",
+  "short_name": "Consulta",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "48x48 64x64 96x96 128x128 256x256",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/next.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'consulta-processual-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/favicon.ico',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- enable manifest link and theme color in document
- register service worker
- add web manifest and simple service worker

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1543272c8333a6cf5059720eb681