### PR TITLE
Fix Safari bottom bar clipping

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -155,7 +155,7 @@ export default function App() {
   // --- Render Method ---
 
   return (
-    <div className="flex flex-col h-screen bg-[#fff] text-blue font-sans">
+    <div className="flex flex-col safe-h-screen bg-[#fff] text-blue font-sans">
       {/* Header */}
       <header className="flex items-center justify-between p-4 border-b border-gray-700/50 flex-shrink-0">
         <div className="flex items-center gap-4">

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -2,7 +2,7 @@ import { LoginForm } from "@/components/login-form";
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen w-full items-center justify-center p-6 md:p-10">
+    <div className="flex safe-h-screen w-full items-center justify-center p-6 md:p-10">
       <div className="w-full max-w-sm">
         <LoginForm />
       </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -25,3 +25,13 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Handle Safari's bottom bar by using the dynamic viewport height when available */
+.safe-h-screen {
+  height: calc(100vh - env(safe-area-inset-bottom));
+}
+@supports (height: 100dvh) {
+  .safe-h-screen {
+    height: 100dvh;
+  }
+}


### PR DESCRIPTION
## Summary
- handle Safari bottom bar with new CSS utility
- apply the utility in chat and login pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e199726f4833395c0fa97e21c0bb4