### PR TITLE
Remove textarea border

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -249,7 +249,7 @@ export default function App() {
               onKeyPress={handleKeyPress}
               placeholder="Digite o Número do Processo..."
               rows={1}
-              className="flex-1 bg-transparent p-2 resize-none outline-none placeholder-white border border-white text-[105%] font-bold"
+              className="flex-1 bg-transparent p-2 resize-none outline-none placeholder-white text-[105%] font-bold"
               style={{ maxHeight: '150px' }}
               inputMode="numeric"
             />


### PR DESCRIPTION
## Summary
- clean up textarea style by removing the border classes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed691313c8333a13614c609fa649c