### PR TITLE
Add court selection

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -8,10 +8,15 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { numeroProcesso } = req.body
+  const { numeroProcesso, tribunal } = req.body
   if (!numeroProcesso) {
     return res.status(400).json({ error: 'Missing numeroProcesso' })
   }
+
+  const endpoint =
+    tribunal === 'TJRJ'
+      ? 'https://api-publica.datajud.cnj.jus.br/api_publica_tjrj/_search'
+      : 'https://api-publica.datajud.cnj.jus.br/api_publica_trf2/_search'
 
   const payload = {
     query: {
@@ -23,7 +28,7 @@ export default async function handler(
 
   try {
     const dataRes = await fetch(
-      'https://api-publica.datajud.cnj.jus.br/api_publica_trf1/_search',
+      endpoint,
       {
         method: 'POST',
         headers: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,6 +13,8 @@ export default function App() {
   const [inputValue, setInputValue] = useState('');
   // State to track if the bot is "thinking"
   const [isLoading, setIsLoading] = useState(false);
+  // State to store selected court
+  const [selectedCourt, setSelectedCourt] = useState('TRF2');
 
   // Ref to the chat container for auto-scrolling
   const chatEndRef = useRef<HTMLDivElement>(null);
@@ -126,7 +128,7 @@ export default function App() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ numeroProcesso: trimmedInput }),
+        body: JSON.stringify({ numeroProcesso: trimmedInput, tribunal: selectedCourt }),
       });
 
       if (!res.ok) {
@@ -240,6 +242,14 @@ export default function App() {
         
           {/* Text Input Area #2a2b30 #2a365e*/}
           <div className="relative flex items-center p-2 bg-[#2a365e] border border-white rounded-2xl">
+            <select
+              value={selectedCourt}
+              onChange={(e) => setSelectedCourt(e.target.value)}
+              className="mr-2 p-2 rounded-lg text-black"
+            >
+              <option value="TRF2">TRF2</option>
+              <option value="TJRJ">TJRJ</option>
+            </select>
             <textarea
               value={inputValue}
               onChange={(e) => {


### PR DESCRIPTION
## Summary
- let users choose TRF2 or TJRJ when searching
- call Datajud with the chosen court

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1efe10348333baa4509657a90310