### PR TITLE
Display TRF2 Eproc scraped events in chat

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -83,7 +83,7 @@ export default async function handler(
       const chatData = await chatRes.json()
       const summary = chatData.choices?.[0]?.message?.content ?? ''
 
-      return res.status(200).json({ summary })
+      return res.status(200).json({ summary, events })
     } catch (error) {
       console.error(error)
       return res

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -136,6 +136,10 @@ export default function App() {
       }
 
       const data = await res.json();
+      if (data.events) {
+        const raw = Array.isArray(data.events) ? data.events.join('\n') : String(data.events);
+        typeBotMessage(`Eventos TRF2-Eproc:\n${raw}`);
+      }
       const message = data.summary ?? JSON.stringify(data, null, 2);
       typeBotMessage(message);
     } catch (error) {


### PR DESCRIPTION
## Summary
- return scraped events from TRF2 Eproc endpoint
- show those events to the user before the summary

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605e20ec3c8333a9a67dae1481ac94