### PR TITLE
Fix build by stubbing puppeteer module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/types/puppeteer.d.ts
+++ b/types/puppeteer.d.ts
@@ -1,0 +1,1 @@
+declare module 'puppeteer'


### PR DESCRIPTION
## Summary
- include d.ts files in tsconfig
- add stub declaration for `puppeteer` to avoid type errors during Netlify build

## Testing
- `npm run build` *(fails: next not found because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68607b4160348333a333dd48c1631604