### PR TITLE
Implement 2captcha turnstile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # consulta-processual-app
+
+This project provides a small Next.js application to query court information.
+
+## Environment
+
+Set `OPENAI_API_KEY` for OpenAI requests and `TWOCAPTCHA_API_KEY` for solving Cloudflare Turnstile challenges.
+


### PR DESCRIPTION
## Summary
- rewrite README with env setup notes
- add Turnstile solver using 2captcha
- adapt TRF2 scraping to automatically solve the captcha

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686082d990c08333876bbbbfcb20e7cf