### PR TITLE
Fix implicit any error

### DIFF
--- a/pages/api/trf2/eproc.ts
+++ b/pages/api/trf2/eproc.ts
@@ -107,7 +107,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   const { browser, page, siteKey, pageUrl } = session
   try {
     const cfToken = await solveTurnstile(siteKey, pageUrl)
-    await page.evaluate((t) => {
+    await page.evaluate((t: string) => {
       const input = document.querySelector('input[name="cf-turnstile-response"]') as HTMLInputElement | null
       if (input) input.value = t
     }, cfToken)


### PR DESCRIPTION
## Summary
- fix implicit `any` in puppeteer `page.evaluate` for TRF2 eproc handler

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a2684f788333b9bf369880172177