### PR TITLE
Update tribunal selector and endpoint

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -22,8 +22,8 @@ export default async function handler(
 
   // Define a URL de acordo com o tribunal escolhido
   const endpoint =
-    tribunal === 'TJRJ'
-      ? 'https://api-publica.datajud.cnj.jus.br/api_publica_tjrj/_search'
+    tribunal === 'TRT1'
+      ? 'https://api-publica.datajud.cnj.jus.br/api_publica_trt1/_search'
       : 'https://api-publica.datajud.cnj.jus.br/api_publica_trf2/_search';
 
   // Corpo da requisição para a API do CNJ

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -288,7 +288,7 @@ export default function App() {
             >
               <option value="TRF2">TRF2</option>
               {/* <option value="TRF2-Eproc">TRF2 - Eproc</option> */}
-              <option value="TJRJ">TJRJ</option>
+              <option value="TRT1">TRT1</option>
             </select>
           </div>
 


### PR DESCRIPTION
## Summary
- rename TJRJ tribunal option to TRT1
- update endpoint for TRT1 when querying CNJ API

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e98222488333956e4a08f8cc155b