### PR TITLE
Implement simple dashboard page

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -20,6 +20,16 @@ export function LoginForm({
   className,
   ...props
 }: React.ComponentProps<'div'>) {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const level = (form.elements.namedItem("level") as HTMLSelectElement)?.value;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("userLevel", level || "1");
+    }
+    window.location.href = "/dashboard";
+  }
+
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
       {/* Cartão central que contém o formulário */}
@@ -33,7 +43,7 @@ export function LoginForm({
         </CardHeader>
         <CardContent>
           {/* Campos de entrada do usuário */}
-          <form>
+          <form onSubmit={handleSubmit}>
             <div className="flex flex-col gap-6">
               <div className="grid gap-3">
                 <Label htmlFor="email">Email</Label>
@@ -55,6 +65,13 @@ export function LoginForm({
                   </a>
                 </div>
                 <Input id="password" type="password" required />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="level">Nível</Label>
+                <select id="level" name="level" className="border rounded-md p-2">
+                  <option value="1">Usuário</option>
+                  <option value="0">Admin</option>
+                </select>
               </div>
               <div className="flex flex-col gap-3">
                 {/* Botões de ação */}

--- a/pages/api/processos.ts
+++ b/pages/api/processos.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+interface Processo {
+  id: number;
+  numero: string;
+  descricao: string;
+  ownerId: number;
+}
+
+const dados: Processo[] = [
+  { id: 1, numero: "1234567-89.2024.1.00.0001", descricao: "Ação trabalhista", ownerId: 1 },
+  { id: 2, numero: "2345678-90.2024.1.00.0002", descricao: "Recurso fiscal", ownerId: 2 },
+  { id: 3, numero: "3456789-01.2024.1.00.0003", descricao: "Inventário", ownerId: 1 },
+];
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const level = Number(req.query.level ?? 1);
+
+  if (level === 1) {
+    const result = dados.filter((p) => p.ownerId === 1);
+    return res.status(200).json({ processos: result });
+  }
+
+  return res.status(200).json({ processos: dados });
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+interface Processo {
+  id: number;
+  numero: string;
+  descricao: string;
+  ownerId: number;
+}
+
+export default function Dashboard() {
+  const router = useRouter();
+  const [level, setLevel] = useState<number>(1);
+  const [tab, setTab] = useState<string>("meus");
+  const [processos, setProcessos] = useState<Processo[]>([]);
+
+  // Nível pode vir de localStorage ou query, aqui apenas exemplo
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const stored = window.localStorage.getItem("userLevel");
+      if (stored) setLevel(Number(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/api/processos?level=${level}`);
+      const data = await res.json();
+      setProcessos(data.processos);
+    }
+    load();
+  }, [level]);
+
+  const filtered = tab === "meus"
+    ? processos.filter((p) => p.ownerId === 1 || level === 0)
+    : processos;
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Sidebar */}
+      <aside className="w-64 bg-gray-100 border-r p-4 space-y-2">
+        {level === 1 && (
+          <button
+            className={`block w-full text-left px-3 py-2 rounded-md ${tab === "meus" ? "bg-gray-200" : ""}`}
+            onClick={() => setTab("meus")}
+          >
+            Meus Processos
+          </button>
+        )}
+        {level === 0 && (
+          <>
+            <button
+              className={`block w-full text-left px-3 py-2 rounded-md ${tab === "notificados" ? "bg-gray-200" : ""}`}
+              onClick={() => setTab("notificados")}
+            >
+              Processos Notificados
+            </button>
+            <button
+              className={`block w-full text-left px-3 py-2 rounded-md ${tab === "escritorios" ? "bg-gray-200" : ""}`}
+              onClick={() => setTab("escritorios")}
+            >
+              Gestão de Escritórios
+            </button>
+          </>
+        )}
+      </aside>
+
+      {/* Main */}
+      <div className="flex-1 flex flex-col">
+        <header className="flex justify-end border-b p-4">
+          <Link href="/login" className="text-sm font-semibold underline">
+            Sair
+          </Link>
+        </header>
+
+        <main className="p-4 flex-1 overflow-y-auto">
+          {tab === "meus" && (
+            <div>
+              <h1 className="text-xl font-bold mb-4">Meus Processos</h1>
+              <table className="min-w-full border text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="border px-2 py-1 text-left">Número</th>
+                    <th className="border px-2 py-1 text-left">Descrição</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((p) => (
+                    <tr key={p.id}>
+                      <td className="border px-2 py-1">{p.numero}</td>
+                      <td className="border px-2 py-1">{p.descricao}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {level === 0 && tab === "notificados" && (
+            <div>
+              <h1 className="text-xl font-bold mb-4">Processos Notificados</h1>
+              <table className="min-w-full border text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="border px-2 py-1 text-left">Número</th>
+                    <th className="border px-2 py-1 text-left">Descrição</th>
+                    <th className="border px-2 py-1 text-left">Responsável</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {processos.map((p) => (
+                    <tr key={p.id}>
+                      <td className="border px-2 py-1">{p.numero}</td>
+                      <td className="border px-2 py-1">{p.descricao}</td>
+                      <td className="border px-2 py-1">Usuário {p.ownerId}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {level === 0 && tab === "escritorios" && (
+            <div>
+              <h1 className="text-xl font-bold mb-4">Gestão de Escritórios</h1>
+              <p>Área restrita ao administrador.</p>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a mock API endpoint to list processos
- create a dashboard page with sidebar and logout link
- update login form to store user level and redirect to dashboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68633defb3e08333b2ec77cc09503857