### PR TITLE
Add shadcn-style dashboard layout

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,0 +1,101 @@
+import * as React from "react"
+import { ChevronRight } from "lucide-react"
+
+import { SearchForm } from "@/components/search-form"
+import { VersionSwitcher } from "@/components/version-switcher"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from "@/components/ui/sidebar"
+
+const data = {
+  versions: ["1.0.1", "1.1.0-alpha", "2.0.0-beta1"],
+  navMain: [
+    {
+      title: "Getting Started",
+      url: "#",
+      items: [
+        {
+          title: "Installation",
+          url: "#",
+        },
+        {
+          title: "Project Structure",
+          url: "#",
+        },
+      ],
+    },
+    {
+      title: "Building Your Application",
+      url: "#",
+      items: [
+        {
+          title: "Routing",
+          url: "#",
+        },
+        {
+          title: "Data Fetching",
+          url: "#",
+          isActive: true,
+        },
+        {
+          title: "Rendering",
+          url: "#",
+        },
+      ],
+    },
+  ],
+}
+
+export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar {...props}>
+      <SidebarHeader>
+        <VersionSwitcher versions={data.versions} defaultVersion={data.versions[0]} />
+        <SearchForm />
+      </SidebarHeader>
+      <SidebarContent className="gap-0">
+        {data.navMain.map((item) => (
+          <Collapsible key={item.title} defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel asChild className="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm">
+                <CollapsibleTrigger>
+                  {item.title}
+                  <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {item.items.map((child) => (
+                      <SidebarMenuItem key={child.title}>
+                        <SidebarMenuButton asChild isActive={child.isActive}>
+                          <a href={child.url}>{child.title}</a>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    ))}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
+        ))}
+      </SidebarContent>
+      <SidebarRail />
+    </Sidebar>
+  )
+}
+

--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -1,0 +1,25 @@
+import { Search } from "lucide-react"
+
+import { Label } from "@/components/ui/label"
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarInput,
+} from "@/components/ui/sidebar"
+
+export function SearchForm({ ...props }: React.ComponentProps<"form">) {
+  return (
+    <form {...props}>
+      <SidebarGroup className="py-0">
+        <SidebarGroupContent className="relative">
+          <Label htmlFor="search" className="sr-only">
+            Search
+          </Label>
+          <SidebarInput id="search" placeholder="Search the docs..." className="pl-8" />
+          <Search className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 opacity-50 select-none" />
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </form>
+  )
+}
+

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export function Breadcrumb({ className, ...props }: React.HTMLAttributes<HTMLElement>) {
+  return <nav className={cn("flex items-center text-sm", className)} {...props} />
+}
+
+export function BreadcrumbList({ className, ...props }: React.OlHTMLAttributes<HTMLOListElement>) {
+  return <ol className={cn("flex items-center gap-2", className)} {...props} />
+}
+
+export function BreadcrumbItem({ className, ...props }: React.LiHTMLAttributes<HTMLLIElement>) {
+  return <li className={cn("flex items-center gap-2", className)} {...props} />
+}
+
+export function BreadcrumbLink({ className, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return <a className={cn("hover:underline", className)} {...props} />
+}
+
+export function BreadcrumbPage({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return <span className={cn("font-semibold", className)} {...props} />
+}
+
+export function BreadcrumbSeparator({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return <span className={cn("", className)} aria-hidden="true" {...props}>/</span>
+}
+

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+
+interface CollapsibleContextValue {
+  open: boolean
+  setOpen: (open: boolean) => void
+}
+
+const CollapsibleContext = React.createContext<CollapsibleContextValue | null>(null)
+
+export function Collapsible({ defaultOpen, children, ...props }: { defaultOpen?: boolean } & React.HTMLAttributes<HTMLDivElement>) {
+  const [open, setOpen] = React.useState(!!defaultOpen)
+  return (
+    <CollapsibleContext.Provider value={{ open, setOpen }}>
+      <div data-state={open ? "open" : "closed"} {...props}>{children}</div>
+    </CollapsibleContext.Provider>
+  )
+}
+
+export function CollapsibleTrigger({ children, ...props }: React.HTMLAttributes<HTMLButtonElement>) {
+  const context = React.useContext(CollapsibleContext)
+  if (!context) return null
+  const { open, setOpen } = context
+  return (
+    <button type="button" aria-expanded={open} onClick={() => setOpen(!open)} {...props}>
+      {children}
+    </button>
+  )
+}
+
+export function CollapsibleContent({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const context = React.useContext(CollapsibleContext)
+  if (!context) return null
+  const { open } = context
+  return open ? <div {...props}>{children}</div> : null
+}
+

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical"
+}
+
+export function Separator({ orientation = "horizontal", className, ...props }: SeparatorProps) {
+  return (
+    <div
+      role="separator"
+      className={cn(
+        "bg-gray-200",
+        orientation === "vertical" ? "w-px h-full" : "h-px w-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+

--- a/components/ui/sidebar/index.tsx
+++ b/components/ui/sidebar/index.tsx
@@ -1,0 +1,98 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface SidebarContextValue {
+  open: boolean
+  setOpen: (open: boolean) => void
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | null>(null)
+
+export function SidebarProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+  return (
+    <SidebarContext.Provider value={{ open, setOpen }}>
+      <div className="flex w-full">{children}</div>
+    </SidebarContext.Provider>
+  )
+}
+
+export function SidebarTrigger({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  const context = React.useContext(SidebarContext)
+  if (!context) return null
+  const { open, setOpen } = context
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(!open)}
+      aria-expanded={open}
+      className={cn(className)}
+      {...props}
+    >
+      ≡
+    </button>
+  )
+}
+
+export function SidebarInset({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex-1", className)} {...props} />
+}
+
+export function Sidebar({ className, ...props }: React.HTMLAttributes<HTMLElement>) {
+  const context = React.useContext(SidebarContext)
+  if (!context) return null
+  const { open } = context
+  return (
+    <aside
+      className={cn("w-64 border-r bg-gray-100 p-4", !open && "hidden md:block", className)}
+      {...props}
+    />
+  )
+}
+
+export function SidebarRail() {
+  return null
+}
+
+export function SidebarHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mb-4", className)} {...props} />
+}
+
+export function SidebarContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("space-y-4", className)} {...props} />
+}
+
+export function SidebarGroup({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mb-2", className)} {...props} />
+}
+
+export function SidebarGroupLabel({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("font-medium", className)} {...props} />
+}
+
+export function SidebarGroupContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("ml-2", className)} {...props} />
+}
+
+export function SidebarMenu({ className, ...props }: React.HTMLAttributes<HTMLUListElement>) {
+  return <ul className={cn("space-y-1", className)} {...props} />
+}
+
+export function SidebarMenuItem({ className, ...props }: React.LiHTMLAttributes<HTMLLIElement>) {
+  return <li className={cn(className)} {...props} />
+}
+
+export function SidebarMenuButton({ isActive, className, ...props }: { isActive?: boolean } & React.HTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn("w-full text-left", isActive && "font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+export function SidebarInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input className="w-full rounded border px-2 py-1" {...props} />
+}
+
+

--- a/components/version-switcher.tsx
+++ b/components/version-switcher.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
+
+interface VersionSwitcherProps {
+  versions: string[]
+  defaultVersion: string
+}
+
+export function VersionSwitcher({ versions, defaultVersion, className, ...props }: VersionSwitcherProps & React.HTMLAttributes<HTMLDivElement>) {
+  const [version, setVersion] = React.useState(defaultVersion)
+  return (
+    <div className={cn("space-y-1", className)} {...props}>
+      <Label className="text-xs" htmlFor="version-select">Version</Label>
+      <select
+        id="version-select"
+        value={version}
+        onChange={(e) => setVersion(e.target.value)}
+        className="w-full rounded border px-2 py-1 text-sm"
+      >
+        {versions.map((v) => (
+          <option key={v} value={v}>{v}</option>
+        ))}
+      </select>
+    </div>
+  )
+}
+

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,134 +1,46 @@
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { useRouter } from "next/router";
+import { AppSidebar } from "@/components/app-sidebar"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { Separator } from "@/components/ui/separator"
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar"
 
-interface Processo {
-  id: number;
-  numero: string;
-  descricao: string;
-  ownerId: number;
-}
-
-export default function Dashboard() {
-  const router = useRouter();
-  const [level, setLevel] = useState<number>(1);
-  const [tab, setTab] = useState<string>("meus");
-  const [processos, setProcessos] = useState<Processo[]>([]);
-
-  // Nível pode vir de localStorage ou query, aqui apenas exemplo
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const stored = window.localStorage.getItem("userLevel");
-      if (stored) setLevel(Number(stored));
-    }
-  }, []);
-
-  useEffect(() => {
-    async function load() {
-      const res = await fetch(`/api/processos?level=${level}`);
-      const data = await res.json();
-      setProcessos(data.processos);
-    }
-    load();
-  }, [level]);
-
-  const filtered = tab === "meus"
-    ? processos.filter((p) => p.ownerId === 1 || level === 0)
-    : processos;
-
+export default function DashboardPage() {
   return (
-    <div className="flex min-h-screen">
-      {/* Sidebar */}
-      <aside className="w-64 bg-gray-100 border-r p-4 space-y-2">
-        {level === 1 && (
-          <button
-            className={`block w-full text-left px-3 py-2 rounded-md ${tab === "meus" ? "bg-gray-200" : ""}`}
-            onClick={() => setTab("meus")}
-          >
-            Meus Processos
-          </button>
-        )}
-        {level === 0 && (
-          <>
-            <button
-              className={`block w-full text-left px-3 py-2 rounded-md ${tab === "notificados" ? "bg-gray-200" : ""}`}
-              onClick={() => setTab("notificados")}
-            >
-              Processos Notificados
-            </button>
-            <button
-              className={`block w-full text-left px-3 py-2 rounded-md ${tab === "escritorios" ? "bg-gray-200" : ""}`}
-              onClick={() => setTab("escritorios")}
-            >
-              Gestão de Escritórios
-            </button>
-          </>
-        )}
-      </aside>
-
-      {/* Main */}
-      <div className="flex-1 flex flex-col">
-        <header className="flex justify-end border-b p-4">
-          <Link href="/login" className="text-sm font-semibold underline">
-            Sair
-          </Link>
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <header className="bg-background sticky top-0 flex h-16 shrink-0 items-center gap-2 border-b px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 h-4" />
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem className="hidden md:block">
+                <BreadcrumbLink href="#">Building Your Application</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator className="hidden md:block" />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Data Fetching</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
         </header>
-
-        <main className="p-4 flex-1 overflow-y-auto">
-          {tab === "meus" && (
-            <div>
-              <h1 className="text-xl font-bold mb-4">Meus Processos</h1>
-              <table className="min-w-full border text-sm">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="border px-2 py-1 text-left">Número</th>
-                    <th className="border px-2 py-1 text-left">Descrição</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtered.map((p) => (
-                    <tr key={p.id}>
-                      <td className="border px-2 py-1">{p.numero}</td>
-                      <td className="border px-2 py-1">{p.descricao}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          {level === 0 && tab === "notificados" && (
-            <div>
-              <h1 className="text-xl font-bold mb-4">Processos Notificados</h1>
-              <table className="min-w-full border text-sm">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="border px-2 py-1 text-left">Número</th>
-                    <th className="border px-2 py-1 text-left">Descrição</th>
-                    <th className="border px-2 py-1 text-left">Responsável</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {processos.map((p) => (
-                    <tr key={p.id}>
-                      <td className="border px-2 py-1">{p.numero}</td>
-                      <td className="border px-2 py-1">{p.descricao}</td>
-                      <td className="border px-2 py-1">Usuário {p.ownerId}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          {level === 0 && tab === "escritorios" && (
-            <div>
-              <h1 className="text-xl font-bold mb-4">Gestão de Escritórios</h1>
-              <p>Área restrita ao administrador.</p>
-            </div>
-          )}
-        </main>
-      </div>
-    </div>
-  );
+        <div className="flex flex-1 flex-col gap-4 p-4">
+          {Array.from({ length: 24 }).map((_, index) => (
+            <div key={index} className="bg-muted/50 aspect-video h-12 w-full rounded-lg" />
+          ))}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  )
 }
+


### PR DESCRIPTION
## Summary
- implement new ShadCN inspired sidebar components
- add VersionSwitcher, SearchForm and AppSidebar
- redesign dashboard using Sidebar and Breadcrumb UI

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634362df4c8333926b9edd20da19d0