### PR TITLE
Move login link to sidebar

### DIFF
--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -5,6 +5,7 @@ import {
   Bell,
   ChevronsUpDown,
   CreditCard,
+  LogIn,
   LogOut,
   Sparkles,
 } from "lucide-react"
@@ -101,6 +102,11 @@ export function NavUser({
                 Notifications
               </DropdownMenuItem>
             </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => (window.location.href = "/login")}> 
+              <LogIn />
+              Entrar
+            </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem>
               <LogOut />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -224,15 +224,17 @@ export default function App() {
           <h1 className="text-2xl font-bold font-sans">Acompanhar Processo</h1>
         </div>
         <div className="flex items-center gap-2">
+          {/*
            <Link
              href="/login"
              className="bg-[#2a365e] text-white px-4 py-2 text-sm font-semibold rounded-[0.75rem] shadow-md hover:opacity-90 transition-colors"
            >
             Entrar
            </Link>
-           {/*<button className="p-2 rounded-md hover:bg-gray-700/50 transition-colors">
+          */}
+          {/*<button className="p-2 rounded-md hover:bg-gray-700/50 transition-colors">
             <Bot size={20} />
-           </button>*/}
+          </button>*/}
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- comment out login button in home page header
- add login entry in user dropdown inside sidebar

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656f28bda483339521975b6d0aa87b