### PR TITLE
Atualiza prompts para API do ChatGPT

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -66,9 +66,15 @@ export default async function handler(
           {
             role: 'system',
             content:
-              'Você é um advogado experiente e deve resumir os movimentos do processo baseado na resposta a seguir. A sua resposta deverá separar cada movimento em um parágrafo, devidamente datados, e explique objetivamente o que esse movimento pode representar para o andamento processual. Cada movimento deve ser explicado em até 1 linha',
+              'Você é um especialista jurídico com a missão de explicar o andamento de processos judiciais para clientes leigos. Sua explicação deve ser precisa, didática e compreensível mesmo para quem não entende nada de direito. Evite jargões jurídicos e traduza todos os termos técnicos para uma linguagem do dia a dia.',
           },
-          { role: 'user', content: JSON.stringify(data) },
+          {
+            role: 'user',
+            content:
+              'Este é o conjunto de dados retornado da API pública com os principais eventos de um processo judicial. Analise o contexto geral do processo e explique de forma clara, objetiva e detalhada o que significa o andamento mais recente. Use uma linguagem simples, como se estivesse explicando para alguém que não tem nenhum conhecimento jurídico. Informe também, se possível, quais são os próximos passos que podem ocorrer nesse processo.\n\nAqui estão os dados:\n\n```json\n' +
+              JSON.stringify(data) +
+              '\n```',
+          },
         ],
         max_tokens: 1000,
       }),

--- a/pages/api/trf2/eproc.ts
+++ b/pages/api/trf2/eproc.ts
@@ -136,11 +136,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Fecha o navegador após a extração
     await browser.close()
 
-    const prompt =
-      'Explique de forma clara e simples para um usuário leigo os dois últimos eventos deste processo judicial: ' +
-      JSON.stringify(data.events)
-
-    // Envia para o GPT gerar um resumo dos eventos
+    // Constrói as mensagens para o ChatGPT
     const chatRes = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -149,7 +145,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
       body: JSON.stringify({
         model: 'gpt-4o',
-        messages: [{ role: 'user', content: prompt }],
+        messages: [
+          {
+            role: 'system',
+            content:
+              'Você é um especialista jurídico com a missão de explicar o andamento de processos judiciais para clientes leigos. Sua explicação deve ser precisa, didática e compreensível mesmo para quem não entende nada de direito. Evite jargões jurídicos e traduza todos os termos técnicos para uma linguagem do dia a dia.',
+          },
+          {
+            role: 'user',
+            content:
+              'Este é o conjunto de dados retornado da API pública com os principais eventos de um processo judicial. Analise o contexto geral do processo e explique de forma clara, objetiva e detalhada o que significa o andamento mais recente. Use uma linguagem simples, como se estivesse explicando para alguém que não tem nenhum conhecimento jurídico. Informe também, se possível, quais são os próximos passos que podem ocorrer nesse processo.\n\nAqui estão os dados:\n\n```json\n' +
+              JSON.stringify(data.events) +
+              '\n```',
+          },
+        ],
         max_tokens: 200,
       }),
     })


### PR DESCRIPTION
## Resumo
- atualiza a rota `/api/search` para usar prompts mais explicativos
- ajusta a rota `/api/trf2/eproc` com as mesmas mensagens

## Testes
- `npm run lint` *(falha: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867436e03148333820c4003acfa0be4