### PR TITLE
Remove GPT summarization from API endpoints

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -53,6 +53,10 @@ export default async function handler(
 
     const data = await dataRes.json()
 
+    // Retorna apenas o JSON obtido da API CNJ
+    return res.status(200).json(data)
+
+    /*
     // Utiliza o GPT para resumir os dados encontrados
     const chatRes = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -83,6 +87,7 @@ export default async function handler(
     const summary = chatData.choices?.[0]?.message?.content ?? ''
 
     return res.status(200).json({ summary })
+    */
   } catch (error) {
     console.error(error)
     return res.status(500).json({ error: 'Failed to fetch' })

--- a/pages/api/trf2/eproc.ts
+++ b/pages/api/trf2/eproc.ts
@@ -136,6 +136,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Fecha o navegador após a extração
     await browser.close()
 
+    // Retorna apenas o JSON extraído da página
+    return res.status(200).json(data)
+
+    /*
     const prompt =
       'Explique de forma clara e simples para um usuário leigo os dois últimos eventos deste processo judicial: ' +
       JSON.stringify(data.events)
@@ -162,6 +166,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const resumo = chatData.choices?.[0]?.message?.content || ''
 
     return res.status(200).json({ ...data, resumo })
+    */
   } catch (err) {
     console.error(err)
     // Garante que o navegador seja fechado em caso de erro


### PR DESCRIPTION
## Summary
- return raw JSON from CNJ search and TRF2 eproc endpoints
- keep previous GPT code commented for reference

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868576f62e48333a1cd617adcf2e5fd