### PR TITLE
Align browser color with header

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,7 +8,7 @@ export default function Document() {
       <Head>
         {/* Configurações de PWA */}
         <link rel="manifest" href="/manifest.json" />
-        <meta name="theme-color" content="#000000" />
+        <meta name="theme-color" content="#2a365e" />
       </Head>
       <body className="antialiased">
         <Main />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#000000",
+  "theme_color": "#2a365e",
   "icons": [
     {
       "src": "/favicon.ico",


### PR DESCRIPTION
## Summary
- match theme color with the header color in `_document.tsx`
- keep manifest theme color consistent

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5c43333c8333927190250d0a1c79