### PR TITLE
Make eproc puppeteer browser visible

### DIFF
--- a/pages/api/trf2/eproc.ts
+++ b/pages/api/trf2/eproc.ts
@@ -81,8 +81,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const puppeteer = await loadPuppeteer()
-  // Abre navegador em modo headless
-  const browser = await puppeteer.launch({ headless: 'new' })
+  // Abre navegador visível para depuração
+  const browser = await puppeteer.launch({ headless: false })
   const page = await browser.newPage()
   await page.setUserAgent(
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'


### PR DESCRIPTION
## Summary
- show the browser during TRF2 eproc scraping to allow watching the process

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc3200de08333843a76bdc38ebcc9