### PR TITLE
Fix Turnstile siteKey handling

### DIFF
--- a/components/turnstile-widget.tsx
+++ b/components/turnstile-widget.tsx
@@ -23,8 +23,12 @@ export default function TurnstileWidget({ siteKey, onSuccess, onExpired }: Turns
 
   useEffect(() => {
     if (!scriptLoaded || !(window as any).turnstile || !divRef.current) return
+    if (!siteKey) {
+      console.warn('Turnstile siteKey is missing')
+      return
+    }
     idRef.current = (window as any).turnstile.render(divRef.current, {
-      sitekey: siteKey,
+      sitekey: String(siteKey),
       callback: 'onTurnstileSuccess',
       'expired-callback': 'onTurnstileExpired',
       'error-callback': 'onTurnstileExpired'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -371,7 +371,7 @@ export default function App() {
       {court === 'TRF2-Captcha' && (
         <div className="mb-3">
           <TurnstileWidget
-            siteKey={process.env.NEXT_PUBLIC_CF_SITE_KEY ?? ''}
+            siteKey={String(process.env.NEXT_PUBLIC_CF_SITE_KEY ?? '')}
             onSuccess={(t) => setCaptchaToken(t)}
             onExpired={() => setCaptchaToken('')}
           />


### PR DESCRIPTION
## Summary
- ensure `siteKey` is a valid string before rendering Turnstile
- cast env var to string when passing to the widget

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686e60d95208833384ce52d0ad3d26dc