### PR TITLE
Add env var checks for API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ This project provides a small Next.js application to query court information.
 
 ## Environment
 
-Set `OPENAI_API_KEY` for OpenAI requests and `TWOCAPTCHA_API_KEY` for solving Cloudflare Turnstile challenges.
+Set `OPENAI_API_KEY` for OpenAI requests, `TWOCAPTCHA_API_KEY` for solving Cloudflare Turnstile challenges and `DATAJUD_API_KEY` for accessing CNJ data.
 

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -20,6 +20,10 @@ export default async function handler(
     return res.status(400).json({ error: 'Missing numeroProcesso' })
   }
 
+  if (!process.env.DATAJUD_API_KEY) {
+    return res.status(503).json({ error: 'DATAJUD_API_KEY not configured' })
+  }
+
   // Define a URL de acordo com o tribunal escolhido
   const endpoint =
     tribunal === 'TRT1'

--- a/pages/api/trf2/captcha.ts
+++ b/pages/api/trf2/captcha.ts
@@ -72,6 +72,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'Missing numeroProcesso' })
   }
 
+  if (!process.env.TWOCAPTCHA_API_KEY) {
+    return res.status(503).json({ error: 'TWOCAPTCHA_API_KEY not configured' })
+  }
+
   const puppeteer = await loadPuppeteer()
   const browser = await puppeteer.launch({
     headless: 'new',

--- a/pages/api/trf2/eproc.ts
+++ b/pages/api/trf2/eproc.ts
@@ -86,6 +86,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'Missing numeroProcesso' })
   }
 
+  if (!process.env.TWOCAPTCHA_API_KEY) {
+    return res.status(503).json({ error: 'TWOCAPTCHA_API_KEY not configured' })
+  }
+
   const puppeteer = await loadPuppeteer()
   
   // Abre navegador visível para depuração


### PR DESCRIPTION
## Summary
- handle missing API keys in server routes
- document required `DATAJUD_API_KEY` env var

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e848ab11083338b46bb2fca88c65a