### PR TITLE
Fix TRF2 captcha click timeout

### DIFF
--- a/pages/api/trf2/captcha.ts
+++ b/pages/api/trf2/captcha.ts
@@ -85,6 +85,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const page = await browser.newPage()
+    page.setDefaultTimeout(60000)
 
     await page.evaluateOnNewDocument(() => {
       Object.defineProperty(navigator, 'webdriver', { get: () => false })
@@ -124,6 +125,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       numeroProcesso
     )
 
+    await page.waitForSelector('button[type="submit"]', { visible: true })
     await page.click('button[type="submit"]')
     await page.waitForSelector('table.infraTable', { timeout: 60000 })
 


### PR DESCRIPTION
## Summary
- avoid click timeout by waiting for the submit button
- raise the page default timeout

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686eeee1e7a48333b9e24db05eec2818