### PR TITLE
Fix click for TRF2 captcha handler

### DIFF
--- a/pages/api/trf2/captcha.ts
+++ b/pages/api/trf2/captcha.ts
@@ -126,7 +126,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     )
 
     await page.waitForSelector('button[type="submit"]', { visible: true })
-    await page.click('button[type="submit"]')
+    await page.$eval(
+      'button[type="submit"]',
+      (btn) => (btn as HTMLElement).click()
+    )
     await page.waitForSelector('table.infraTable', { timeout: 60000 })
 
     const data = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
- fix captcha submission by using DOM click instead of `page.click`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef10e2dec833392c3e92aecb1e99e