### PR TITLE
Add bottom navigation bar

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { Home, ClipboardList, Menu as MenuIcon } from 'lucide-react'
+import { SidebarTrigger } from '@/components/ui/sidebar'
+
+export function BottomNav() {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background flex justify-around items-center py-2">
+      <Link href="/" className="flex flex-col items-center text-xs gap-1">
+        <Home className="size-6" />
+        Início
+      </Link>
+      <Link href="/dashboard" className="-mt-6 rounded-full bg-primary text-primary-foreground p-3 shadow-lg flex flex-col items-center text-xs gap-1">
+        <ClipboardList className="size-6" />
+        Processos
+      </Link>
+      <SidebarTrigger className="flex flex-col items-center text-xs gap-1" aria-label="Menu">
+        <MenuIcon className="size-6" />
+        Menu
+      </SidebarTrigger>
+    </nav>
+  )
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -14,6 +14,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar"
+import { BottomNav } from "@/components/bottom-nav"
 
 export default function DashboardPage() {
   return (
@@ -55,6 +56,7 @@ export default function DashboardPage() {
             </div>
           </div>
         </SidebarInset>
+        <BottomNav />
       </SidebarProvider>
     </>
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { useState, useRef, useEffect } from 'react';
 import { Bot, User, Send, Mic, Search, Cpu } from 'lucide-react';
 import { AppSidebar } from '@/components/app-sidebar'
+import { BottomNav } from '@/components/bottom-nav'
 import {
   SidebarProvider,
   SidebarInset,
@@ -423,6 +424,7 @@ export default function App() {
       </footer>
           </div>
         </SidebarInset>
+        <BottomNav />
       </SidebarProvider>
     </>
   );


### PR DESCRIPTION
## Summary
- add BottomNav component
- show bottom nav on home and dashboard pages

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68731731b77c8333a42cc5fd1b3114ec