### PR TITLE
Fix TypeScript implicit any in captcha handler

### DIFF
--- a/pages/api/trf2/captcha.ts
+++ b/pages/api/trf2/captcha.ts
@@ -128,7 +128,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await page.waitForSelector('button[type="submit"]', { visible: true })
     await page.$eval(
       'button[type="submit"]',
-      (btn) => (btn as HTMLElement).click()
+      (btn: HTMLElement) => btn.click()
     )
     await page.waitForSelector('table.infraTable', { timeout: 60000 })
 


### PR DESCRIPTION
## Summary
- type the `btn` parameter in the captcha API to satisfy `noImplicitAny`

## Testing
- `npx next lint` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874f35018888333a65a92368481da77