### PR TITLE
Fix footer overlap on mobile

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -4,7 +4,10 @@ import { SidebarTrigger } from '@/components/ui/sidebar'
 
 export function BottomNav() {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background flex justify-around items-center py-2 md:hidden">
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background flex justify-around items-center pt-2 md:hidden"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.5rem)' }}
+    >
       <Link href="/" className="flex flex-col items-center text-xs gap-1">
         <Home className="size-6" />
         Início

--- a/pages/consulta.tsx
+++ b/pages/consulta.tsx
@@ -314,7 +314,7 @@ export default function ConsultaPage() {
         <AppSidebar />
         <SidebarInset>
           <div
-            className="flex flex-col safe-h-screen bg-[#fff] text-blue font-sans font-medium"
+            className="flex flex-col safe-h-screen pb-20 md:pb-0 bg-[#fff] text-blue font-sans font-medium"
             style={{ fontFamily: 'Manrope, sans-serif' }}
           >
       {/*

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -31,7 +31,7 @@ export default function DashboardPage() {
         <AppSidebar />
         <SidebarInset>
           <div
-            className="flex flex-col safe-h-screen bg-[#fff] text-blue font-sans font-medium"
+            className="flex flex-col safe-h-screen pb-20 md:pb-0 bg-[#fff] text-blue font-sans font-medium"
             style={{ fontFamily: 'Manrope, sans-serif' }}
           >
             <header className="bg-background sticky top-0 flex h-16 shrink-0 items-center gap-2 border-b px-4">


### PR DESCRIPTION
## Summary
- ensure bottom nav accounts for safe areas
- add bottom padding to main containers so the footer input isn't hidden

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687691bf4fa883339b6b6ea3f8eee793