### PR TITLE
Fix bottom nav button layout

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -12,7 +12,10 @@ export function BottomNav() {
         <Home className="size-6" />
         Início
       </Link>
-      <Link href="/dashboard" className="-mt-6 rounded-full bg-primary text-primary-foreground p-3 shadow-lg flex flex-col items-center text-xs gap-1">
+      <Link
+        href="/dashboard"
+        className="rounded-full bg-primary text-primary-foreground p-3 shadow-lg flex flex-col items-center text-xs gap-1"
+      >
         <ClipboardList className="size-6" />
         Meus Processos
       </Link>


### PR DESCRIPTION
## Summary
- keep the **Meus Processos** button highlighted but remove the negative margin so it no longer exceeds the menu height

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687699b75f488333a35eba9167ab6e6e