### PR TITLE
Remove destaque preto do botão "Meus Processos" e reduzir altura da barra inferior

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -5,8 +5,11 @@ import { SidebarTrigger } from '@/components/ui/sidebar'
 export function BottomNav() {
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background flex justify-around items-center pt-2 md:hidden"
-      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.5rem)' }}
+      className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background flex justify-around items-center md:hidden"
+      style={{
+        paddingTop: '0.35rem',
+        paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.35rem)'
+      }}
     >
       <Link href="/" className="flex flex-col items-center text-xs gap-1">
         <Home className="size-6" />
@@ -14,7 +17,7 @@ export function BottomNav() {
       </Link>
       <Link
         href="/dashboard"
-        className="rounded-full bg-primary text-primary-foreground p-3 shadow-lg flex flex-col items-center text-xs gap-1"
+        className="flex flex-col items-center text-xs gap-1"
       >
         <ClipboardList className="size-6" />
         Meus Processos


### PR DESCRIPTION
## Summary
- Remove fundo preto e destaque do botão "Meus Processos" na navegação inferior
- Reduz a altura da barra de menu inferior em aproximadamente 30%

## Testing
- `npm test` *(erro: Missing script: "test")*
- `npm run lint` *(solicitação de configuração interativa do ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6894f0afd13883338b2a8825e115057b