### PR TITLE
Remover espaço entre barra de pesquisa e menu inferior

### DIFF
--- a/pages/consulta.tsx
+++ b/pages/consulta.tsx
@@ -314,7 +314,7 @@ export default function ConsultaPage() {
         <AppSidebar />
         <SidebarInset>
           <div
-            className="flex flex-col safe-h-screen pb-20 md:pb-0 bg-[#fff] text-blue font-sans font-medium"
+            className="flex flex-col safe-h-screen pb-[calc(env(safe-area-inset-bottom)+3.5rem)] md:pb-0 bg-[#fff] text-blue font-sans font-medium"
             style={{ fontFamily: 'Manrope, sans-serif' }}
           >
       {/*
@@ -426,7 +426,7 @@ export default function ConsultaPage() {
 
 
           {/* Área de texto para entrada do número */}
-          <div className="relative flex items-center mb-3 p-2 bg-[#2a365e] border border-white rounded-2xl">
+          <div className="relative flex items-center p-2 bg-[#2a365e] border border-white rounded-2xl">
             <textarea
               value={inputValue}
               onChange={(e) => {


### PR DESCRIPTION
## Summary
- ajustar padding inferior para alinhar o container à barra de menu
- remover margem inferior extra no container da busca

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Requires interactive configuration)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cdede8f688333b1bbf6c35e6625ff