### PR TITLE
Move tribunal selector to bottom navigation

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -1,8 +1,11 @@
 import Link from 'next/link'
-import { Home, ClipboardList, Menu as MenuIcon } from 'lucide-react'
+import { ClipboardList, Menu as MenuIcon } from 'lucide-react'
 import { SidebarTrigger } from '@/components/ui/sidebar'
+import { useCourt } from '@/hooks/use-court'
 
 export function BottomNav() {
+  const { court, setCourt } = useCourt()
+
   return (
     <nav
       className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background flex justify-around items-center md:hidden"
@@ -11,10 +14,19 @@ export function BottomNav() {
         paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.35rem)'
       }}
     >
-      <Link href="/" className="flex flex-col items-center text-xs gap-1">
-        <Home className="size-6" />
-        Início
-      </Link>
+      <div className="flex flex-col items-center text-xs gap-1">
+        <select
+          value={court}
+          onChange={(e) => setCourt(e.target.value)}
+          className="bg-transparent text-center text-xs"
+        >
+          <option value="TRF2">TRF2</option>
+          <option value="TRF2-Eproc">TRF2 - Eproc</option>
+          <option value="TRF2-Captcha">TRF2 - Captcha</option>
+          <option value="TRF2-Manual">TRF2 - Captcha Manual</option>
+          <option value="TRT1">TRT1</option>
+        </select>
+      </div>
       <Link
         href="/dashboard"
         className="flex flex-col items-center text-xs gap-1"

--- a/hooks/use-court.tsx
+++ b/hooks/use-court.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react'
+
+interface CourtContextValue {
+  court: string
+  setCourt: (value: string) => void
+}
+
+const CourtContext = createContext<CourtContextValue | undefined>(undefined)
+
+export function CourtProvider({ children }: { children: ReactNode }) {
+  const [court, setCourt] = useState('TRF2')
+
+  return (
+    <CourtContext.Provider value={{ court, setCourt }}>
+      {children}
+    </CourtContext.Provider>
+  )
+}
+
+export function useCourt(): CourtContextValue {
+  const context = useContext(CourtContext)
+  if (!context) {
+    throw new Error('useCourt must be used within a CourtProvider')
+  }
+  return context
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import { useEffect } from "react";
+import { CourtProvider } from "@/hooks/use-court";
 
 /**
  * Componente raiz carregado em todas as páginas.
@@ -21,5 +22,9 @@ export default function App({ Component, pageProps }: AppProps) {
     }
   }, []);
 
-  return <Component {...pageProps} />;
+  return (
+    <CourtProvider>
+      <Component {...pageProps} />
+    </CourtProvider>
+  );
 }

--- a/pages/consulta.tsx
+++ b/pages/consulta.tsx
@@ -5,6 +5,7 @@ import { Bot, User, Send, Mic, Search, Cpu } from 'lucide-react';
 import { AppSidebar } from '@/components/app-sidebar'
 import { BottomNav } from '@/components/bottom-nav'
 import TurnstileWidget from '@/components/turnstile-widget'
+import { useCourt } from '@/hooks/use-court'
 import {
   SidebarProvider,
   SidebarInset,
@@ -26,7 +27,7 @@ export default function ConsultaPage() {
   // Indica se o bot está processando
   const [isLoading, setIsLoading] = useState(false);
   // Tribunal selecionado pelo usuário
-  const [court, setCourt] = useState('TRF2');
+  const { court, setCourt } = useCourt();
   const [result, setResult] = useState<any>(null);
   const [errorMsg, setErrorMsg] = useState('');
   const [captchaSession, setCaptchaSession] = useState<string | null>(null);
@@ -405,26 +406,6 @@ export default function ConsultaPage() {
             </button>
           </div>*/}
         
-          {/* Seletor de tribunal */}
-          <div className="mb-2">
-            <label htmlFor="court" className="mr-2 text-white">Tribunal:</label>
-            <select
-              id="court"
-              value={court}
-              onChange={(e) => setCourt(e.target.value)}
-              className="rounded-md text-white bg-[#2a365e]"
-            >
-              <option value="TRF2">TRF2</option>
-              <option value="TRF2-Eproc">TRF2 - Eproc</option>
-          <option value="TRF2-Captcha">TRF2 - Captcha</option>
-          <option value="TRF2-Manual">TRF2 - Captcha Manual</option>
-          <option value="TRT1">TRT1</option>
-        </select>
-      </div>
-
-
-
-
           {/* Área de texto para entrada do número */}
           <div className="relative flex items-center p-2 bg-[#2a365e] border border-white rounded-2xl">
             <textarea


### PR DESCRIPTION
## Summary
- add CourtContext to share selected tribunal across app
- replace Home button with tribunal selector in bottom navigation
- remove in-page selector from consulta and wrap app with CourtProvider

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt; no results)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cec127ec483338a8d6c4e74349397