### PR TITLE
Enable AI summaries for process queries

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -57,10 +57,10 @@ export default async function handler(
 
     const data = await dataRes.json()
 
-    // Retorna apenas o JSON obtido da API CNJ
-    return res.status(200).json(data)
+    if (!process.env.OPENAI_API_KEY) {
+      return res.status(503).json({ error: 'OPENAI_API_KEY not configured' })
+    }
 
-    /*
     // Utiliza o GPT para resumir os dados encontrados
     const chatRes = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -91,7 +91,6 @@ export default async function handler(
     const summary = chatData.choices?.[0]?.message?.content ?? ''
 
     return res.status(200).json({ summary })
-    */
   } catch (error) {
     console.error(error)
     return res.status(500).json({ error: 'Failed to fetch' })

--- a/pages/api/trf2/eproc.ts
+++ b/pages/api/trf2/eproc.ts
@@ -172,10 +172,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Fecha o navegador após a extração
     await browser.close()
 
-    // Retorna apenas o JSON extraído da página
-    return res.status(200).json(data)
+    if (!process.env.OPENAI_API_KEY) {
+      return res.status(503).json({ error: 'OPENAI_API_KEY not configured' })
+    }
 
-    /*
     const prompt =
       'Explique de forma clara e simples para um usuário leigo os dois últimos eventos deste processo judicial: ' +
       JSON.stringify(data.events)
@@ -202,7 +202,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const resumo = chatData.choices?.[0]?.message?.content || ''
 
     return res.status(200).json({ ...data, resumo })
-    */
   } catch (err) {
     console.error(err)
     // Garante que o navegador seja fechado em caso de erro


### PR DESCRIPTION
## Summary
- Restore OpenAI summaries for CNJ search queries
- Reinstate GPT-based summaries for TRF2 Eproc events

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a0065da30c8333828b1890ed68e5ef